### PR TITLE
[MI-2625]: Removed length constraints on date and time in date and time picker respectively

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -289,8 +289,6 @@ func (p *Plugin) handleSetDateTimeDialog(w http.ResponseWriter, r *http.Request)
 		Placeholder: "YYYY-MM-DD",
 		HelpText:    "Please enter the date in the format YYYY-MM-DD. Example: 2001-11-04",
 		Optional:    false,
-		MinLength:   10,
-		MaxLength:   10,
 	}
 
 	time := model.DialogElement{
@@ -300,8 +298,6 @@ func (p *Plugin) handleSetDateTimeDialog(w http.ResponseWriter, r *http.Request)
 		Placeholder: "HH:MM",
 		HelpText:    "Please enter the time in 24 hour format as HH:MM. Example: 20:04",
 		Optional:    false,
-		MinLength:   5,
-		MaxLength:   5,
 	}
 
 	inputType := fmt.Sprintf("%v", postActionIntegrationRequest.Context[DateTimeDialogType])


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Earlier when we were writing a date with a length of less than 10 and time with a length of less than 5 then we were getting error something like `Minimum length is 10.` for date and `Minimum length is 5.` for time. But now we are getting `Please enter a valid date` and `Please enter a valid time` respectively.

![Screenshot from 2023-02-07 17-27-49](https://user-images.githubusercontent.com/107465508/217240787-aad218db-45ad-41bf-af85-f638840df9f6.png)


<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

